### PR TITLE
Paper correction: __has_cpp_attribute(carries_dependency).

### DIFF
--- a/sd6.html
+++ b/sd6.html
@@ -1690,7 +1690,7 @@ Paper(s)
 <code class="sourceCode cpp"><span class="dv">200809</span></code>
 </td>
 <td>
-<span class="citation" data-cites="N2761">[<a href="#ref-N2761" role="doc-biblioref">N2761</a>]</span> Towards support for attributes in C++ (Revision 6)
+<span class="citation" data-cites="N2782">[<a href="#ref-N2782" role="doc-biblioref">N2782</a>]</span> C++ Data-Dependency Ordering: Function Annotation
 </td>
 </tr>
 <tr style="background-color: white">
@@ -3975,6 +3975,10 @@ Paper(s)
 <div id="ref-N2765">
 <p>[N2765] I. McIntosh, M. Wong, R. Mak, R. Klarer, et al. 2008. User-defined Literals (aka. Extensible Literals (revision 5)). <br />
 <a href="https://wg21.link/n2765">https://wg21.link/n2765</a></p>
+</div>
+<div id="ref-N2782">
+<p>[N2782] Paul E. McKenney, Lawrence Crowl. 2008. C++ Data-Dependency Ordering: Function Annotation. <br />
+<a href="https://wg21.link/n2782">https://wg21.link/n2782</a></p>
 </div>
 <div id="ref-N2927">
 <p>[N2927] Daveed Vandevoorde. 2009. New wording for C++0x Lambdas (rev. 2). <br />


### PR DESCRIPTION
I've noticed that the reference of the paper where the `carries_dependency` attribute was proposed is not corrrect. I've added the correct reference.