### PR TITLE
Add char_traits changes from P0432R1 and P1032R1

### DIFF
--- a/macros.yaml
+++ b/macros.yaml
@@ -534,11 +534,17 @@ library:
 - name: __cpp_lib_constexpr_string
   header_list: string
   rows:
+  - value: 201611
+    papers: P0426R1
+  - value: 201811
+    papers: P1032R1
   - value: 201907
     papers: P0980R1
 - name: __cpp_lib_constexpr_string_view
   header_list: string_view
   rows:
+  - value: 201611
+    papers: P0426R1
   - value: 201811
     papers: P1032R1
 - name: __cpp_lib_constexpr_tuple


### PR DESCRIPTION
These papers added constexpr to char_traits members, but there is currently no macro to test whether that is supported.