### PR TITLE
Move `__cpp_lib_unwrap_ref` back to <type_traits>

### DIFF
--- a/macros.yaml
+++ b/macros.yaml
@@ -1050,7 +1050,7 @@ library:
   - value: 201411
     papers: N4279
 - name: __cpp_lib_unwrap_ref
-  header_list: functional
+  header_list: type_traits
   rows:
   - value: 201811
     papers: P0318R1 LWG3348


### PR DESCRIPTION
[LWG3348](http://wg21.link/LWG3348) was resolved by defining `unwrap_reference` and `unwrap_ref_decay` in `<type_traits>`, instead of moving the feature-test macro.