### PR TITLE
Remove __cpp_lib_monadic_optional

### DIFF
--- a/macros.yaml
+++ b/macros.yaml
@@ -858,11 +858,6 @@ library:
   rows:
   - value: 201603
     papers: P0220R1
-- name: __cpp_lib_monadic_optional
-  header_list: optional
-  rows:
-  - value: 202110
-    papers: P0798R8
 - name: __cpp_lib_move_only_function
   header_list: functional
   rows:
@@ -898,6 +893,8 @@ library:
     papers: P0032R3 P0307R2
   - value: 202106
     papers: P2231R1
+  - value: 202110
+    papers: P0798R8
 - name: __cpp_lib_out_ptr
   header_list: memory
   rows:


### PR DESCRIPTION
[LWG 3621](https://wg21.link/lwg3621) bumps `__cpp_lib_optional` instead.

This was approved at the Feb 2022 plenary, so I guess there should be a new `straw_polls/2022_feb.py` file, but I'm not sure what to do there.