### PR TITLE
Fixes for macros.yaml

### DIFF
--- a/macros.yaml
+++ b/macros.yaml
@@ -546,6 +546,11 @@ library:
     papers: P0202R3
   - value: 201806
     papers: P0879R0 LWG3256
+- name: __cpp_lib_constexpr_cmath
+  header_list: cmath cstdlib
+  rows:
+  - value: 202202
+    papers: P0533R9
 - name: __cpp_lib_constexpr_complex
   header_list: complex
   rows:
@@ -618,7 +623,7 @@ library:
     papers: P1004R2
 - name: __cpp_lib_containers_ranges
   header_list: vector list forward_list map set unordered_map unordered_set deque
-    queue priority_queue stack string
+    queue stack string
   rows:
   - value: 202202
     papers: P1206R7
@@ -923,7 +928,7 @@ library:
     papers: P0032R3 P0307R2
   - value: 202106
     papers: P2231R1
-  - value: 202202
+  - value: 202110
     papers: P0798R8 LWG3621
 - name: __cpp_lib_out_ptr
   header_list: memory
@@ -1067,6 +1072,8 @@ library:
   rows:
   - value: 201806
     papers: P0769R2
+  - value: 202202
+    papers: P2440R1
 - name: __cpp_lib_smart_ptr_for_overwrite
   header_list: memory
   rows:


### PR DESCRIPTION
- "[2022-02 LWG Motion 3] [P0533R9] constexpr for `<cmath>` and `<cstdlib>`" adds `__cpp_lib_constexpr_cmath`.
- "[2022-02 LWG Motion 5] [P1206R7] `ranges::to`: A function to convert any range to a container" added `__cpp_lib_containers_ranges` to a nonexistent header `<priority_queue>`. This has been corrected editorially in https://github.com/cplusplus/draft/commit/03b9040814ecd548f2de18668df0655ef7b37efb.
- "[LWG3621] Remove feature-test macro `__cpp_lib_monadic_optional`" increments `__cpp_lib_optional` to `202110` (not `202202`).
- "[2022-02 LWG Motion 10] [P2440R1] `ranges::iota`, `ranges::shift_left` and `ranges::shift_right`" increments `__cpp_lib_shift` (in addition to `__cpp_lib_ranges_iota`).

[P0533R9]: https://wg21.link/p0533r9
[P1206R7]: https://wg21.link/p1206r7
[LWG3621]: https://wg21.link/lwg3621
[P2440R1]: https://wg21.link/p2440r1