### PR TITLE
Fix duplication of P1330R0

### DIFF
--- a/macros.yaml
+++ b/macros.yaml
@@ -109,7 +109,7 @@ language:
   - value: 201806
     papers: P1064R0
   - value: 201811
-    papers: P1002R1 P1327R1 P1330R0
+    papers: P1002R1 P1327R1
   - value: 201907
     papers: P1331R2 P1668R1
   - value: 202002


### PR DESCRIPTION
[P1330R0](https://wg21.link/p1330r0) has been added to the list twice (https://github.com/brevzin/sd6/commit/ca0ccc18d440b731e592b0ada66c706cc9854946 and https://github.com/brevzin/sd6/commit/6d90245da54bcec0a8dafb80bc4c759cdbc6a121).

It seems that the former addition was not intentional and we should only keep the latter one ([P2493R0](https://wg21.link/p2493r0)).