### PR TITLE
Fixes for `macros.yaml`

### DIFF
--- a/macros.yaml
+++ b/macros.yaml
@@ -944,7 +944,7 @@ library:
   header_list: hazard_pointer
   rows:
   - value: 202306
-    papers: P2545R4
+    papers: P2530R3
 - name: __cpp_lib_hypot
   header_list: cmath
   rows:

--- a/macros.yaml
+++ b/macros.yaml
@@ -402,8 +402,8 @@ library:
   rows:
   - value: 202106
     papers: P0401R6
-  - value: 202306
-    papers: LWG3887
+  - value: 202302
+    papers: P2652R2 LWG3887
 - name: __cpp_lib_allocator_traits_is_always_equal
   header_list: memory scoped_allocator string deque forward_list list vector map set
     unordered_map unordered_set

--- a/macros.yaml
+++ b/macros.yaml
@@ -868,7 +868,7 @@ library:
   - value: 202306
     papers: P2198R7
 - name: __cpp_lib_freestanding_operator_new
-  header_list: operator_new
+  header_list: new
   rows:
   - value: 202306
     papers: P2198R7

--- a/macros.yaml
+++ b/macros.yaml
@@ -299,8 +299,8 @@ language:
     papers: N2930
   - value: 201603
     papers: P0184R0
-  - value: 202302
-    papers: P2644R1 P2718R0 CWG2569
+  - value: 202211
+    papers: P2644R1 P2718R0 CWG2659
 - name: __cpp_raw_strings
   rows:
   - value: 200710


### PR DESCRIPTION
- `__cpp_range_based_for` is updated by [CWG 2659](https://cplusplus.github.io/CWG/issues/2659), not 2***56***9, and the chosen value is `202211`.
- `__cpp_lib_allocate_at_least` (last updated by [LWG 3887](https://cplusplus.github.io/LWG/issue3887)) has value `202302`. Also mention the paper [P2652R2](https://wg21.link/P2652R2), which introduced the relevant feature (`allocator_traits::allocate_at_least`).
- The header for `__cpp_lib_freestanding_operator_new` is `<new>`.
- `__cpp_lib_hazard_pointer` is introduced by [P2530R3](https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2023/p2530r3.pdf), not [P2545R4](https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2023/p2545r4.pdf) (Read-Copy Update (RCU)).