### PR TITLE
Update `macros.yaml` to match the draft standard

### DIFF
--- a/macros.yaml
+++ b/macros.yaml
@@ -66,6 +66,10 @@ language:
   rows:
   - value: 200809
     papers: N2761
+- name: __cpp_auto_cast
+  rows:
+  - value: 202110
+    papers: P0849R8
 - name: __cpp_binary_literals
   rows:
   - value: 201304
@@ -812,6 +816,11 @@ library:
   rows:
   - value: 202207
     papers: P2286R8 P2585R1 LWG3750
+- name: __cpp_lib_formatters
+  header_list: stacktrace thread
+  rows:
+  - value: 202302
+    papers: P2693R1
 - name: __cpp_lib_forward_like
   header_list: utility
   rows:
@@ -1390,16 +1399,16 @@ library:
     papers: P0769R2
   - value: 202202
     papers: P2440R1
-- name: __cpp_lib_smart_pointer_owner_equality
-  header_list: memory
-  rows:
-  - value: 202306
-    papers: P1901R2
 - name: __cpp_lib_smart_ptr_for_overwrite
   header_list: memory
   rows:
   - value: 202002
     papers: P1020R1 P1973R1
+- name: __cpp_lib_smart_ptr_owner_equality
+  header_list: memory
+  rows:
+  - value: 202306
+    papers: P1901R2
 - name: __cpp_lib_source_location
   header_list: source_location
   rows:


### PR DESCRIPTION
- Add `__cpp_auto_cast`, which was added editorially in https://github.com/cplusplus/draft/commit/b6903b6fe23d06e23191e672ae287f0de0de472c.
- Add `__cpp_lib_formatter`, which is part of [P2693R1](https://wg21.link/P2693R1) (2023-02 LWG Motion 12).
- Rename `__cpp_lib_smart_pointer_owner_equality` to `__cpp_lib_smart_ptr_owner_equality`. This was renamed editorially in https://github.com/cplusplus/draft/commit/7fb62d5f50bfbfc159df4ca0af932ee82d26bc41.